### PR TITLE
ENH: Introduce new measurement states, allow abort while retaining data

### DIFF
--- a/backend/webtaste_backend/models.py
+++ b/backend/webtaste_backend/models.py
@@ -76,10 +76,8 @@ study = api.model('Study', {
 
 measurement = api.model('Measurement', {
     'number': Integer(description='Measurement Number', required=True),
-    'started': Boolean(description='Staircase started', default=False,
-                       required=True),
-    'finished': Boolean(description='Staircase finished', default=False,
-                        required=True),
+    'state': String(description='State of the measurement', required=True,
+                    enum=['created', 'running', 'finished', 'aborted']),
     'trialsCompletedCount': Integer(description='Number of completed trials',
                                     default=0, required=True),
     'currentTrialNumber': Integer(description='Number of the current trial',
@@ -89,6 +87,12 @@ measurement = api.model('Measurement', {
     'threshold': Float(description='The estimated threshold'),
     'study': Nested(study)
 })
+
+measurement_state = api.model('Measurement', {
+    'state': String(description='State of the measurement', required=True,
+                    enum=['created', 'running', 'finished', 'aborted'])
+})
+
 
 
 user_registration = api.model('User Registration', {
@@ -160,7 +164,7 @@ class Measurement(db.Model):
     study = db.relationship('Study', back_populates='measurements')
 
     number = db.Column(db.Integer, default=1)
-    finished = db.Column(db.Boolean)
+    state = db.Column(db.String(length='20'))
     trialsCompletedCount = db.Column(db.Integer)
     currentTrialNumber = db.Column(db.Integer)
 

--- a/frontend/webtaste_frontend/src/Measurement.js
+++ b/frontend/webtaste_frontend/src/Measurement.js
@@ -341,8 +341,25 @@ class Measurement extends Component {
     })
   };
 
+  _abortMeasurement = async () => {
+    const uri = `/api/${this.props.studyId}` +
+        `/measurements/${this.state.measurementId}`;
+    const payload = JSON.stringify({state: 'aborted'});
+
+    await fetch(uri, {
+      method: 'put',
+      headers: {
+        'Accept': 'application/json, text/plain, */*',
+        'Content-Type': 'application/json'
+      },
+      body: payload,
+      credentials: 'same-origin'
+    })
+  };
+
   abortMeasurement = async () => {
-    await this._deleteMeasurement();
+    // await this._deleteMeasurement();
+    await this._abortMeasurement();
     this.props.onRestart();
   };
 
@@ -357,7 +374,7 @@ class Measurement extends Component {
                                toggle={this.toggleConfirmRestartModal}
                                onConfirm={this.abortMeasurement}
                                header='Abort Measurement'
-                               body='Would you like to abort the current measurement?'
+                               body='Would you like to abort the current measurement?\n\nTheData will still be saved.'
                                confirmButtonText='Abort Measurement'/>
           <strong>Please present jar {this.state.sampleNumber}. </strong><br />
           Did the participant successfully recognize this concentration?<br /><br />
@@ -435,7 +452,7 @@ class Measurement extends Component {
                                toggle={this.toggleConfirmRestartModal}
                                onConfirm={this.abortMeasurement}
                                header='Abort Measurement'
-                               body='Would you like to abort the current measurement?'
+                               body='Would you like to abort the current measurement?\n\nTheData will still be saved.'
                                confirmButtonText='Abort Measurement'/>
           <strong>Please present triade number {this.state.sampleNumber} in the displayed order. </strong><br />
           Which Sniffin' Stick did the participant identify?<br /><br />


### PR DESCRIPTION
Measurements now have a `state` column that can take the values `created`, `running`, `finished`, and `aborted`.

The frontend now retains the data in the DB when aborting a measurement, and sets the `state` value in accordingly.